### PR TITLE
Fix regex used for version scraping

### DIFF
--- a/shared.py
+++ b/shared.py
@@ -13,7 +13,7 @@ import time
 import urllib.request
 
 LESSURL="http://greenwoodsoftware.com/less/download.html"
-version_url_re = re.compile(r"""Download <strong>BETA</strong> version (.*?) """, re.M|re.S|re.I)
+version_url_re = re.compile(r"""Download <strong>RECOMMENDED</strong> version (.*?) """, re.M|re.S|re.I)
 NEWFILE="new.txt"
 
 def download_less_web_page() -> str:
@@ -39,7 +39,7 @@ def download_less_web_page() -> str:
     return page
 
 def get_latest_version_url(page:str) -> tuple:
-    """Return the URL for the "BETA version"
+    """Return the URL for the "RECOMMENDED version"
 
     Args:
         page: an HTML web page, provided in LESSURL


### PR DESCRIPTION
I believe this will fix the [recent build failures](https://ci.appveyor.com/project/jftuga/less-windows/history). I've briefly tested locally: without this change the script exits unsuccessfully with

```
Unable to extract version from: http://greenwoodsoftware.com/less/download.html
```

and with this change it exits successfully with

```
Versions are the same: remote_version: 563   local_version: 563
``` 