### PR TITLE
Add Winget Releaser workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -79,12 +79,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
-    - uses: dev-drprasad/delete-tag-and-release@v0.2.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        delete_release: true
-        tag_name: less-v${{ needs.build.outputs.new_version }}
     - uses: softprops/action-gh-release@v1
       with:
         files: |
@@ -94,3 +88,19 @@ jobs:
         tag_name: less-v${{ needs.checkver.outputs.new_version }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Publish to WinGet
+    - name: Publish less to WinGet
+      uses: vedantmgoyal2009/winget-releaser@latest
+      with:
+        identifier: JohnTaylor.less
+        release-tag: less-v${{ needs.checkver.outputs.new_version }}
+        installers-regex: 'less\.exe$'
+        token: ${{ secrets.WINGET_TOKEN }}
+    - name: Publish lesskey to WinGet
+      uses: vedantmgoyal2009/winget-releaser@latest
+      with:
+        identifier: JohnTaylor.lesskey
+        release-tag: less-v${{ needs.checkver.outputs.new_version }}
+        installers-regex: 'lesskey\.exe$'
+        token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -89,7 +89,12 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    # Publish to WinGet
+  winget:
+    name: Publish to WinGet
+    needs: [checkver, release]
+    runs-on: windows-latest # action can only run on Windows
+
+    steps:
     - name: Publish less to WinGet
       uses: vedantmgoyal2009/winget-releaser@latest
       with:


### PR DESCRIPTION
This action automatically generates manifests for WinGet Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

`less` and `lesskey` is already in Winget, and this workflow will be used to update it.

Before merging this:
1. Add a PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN` (or rename the secret name in the workflow).

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)



2. Fork https://github.com/microsoft/winget-pkgs under @jftuga. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Sign the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs) for winget-pkgs.

If you would like to read about this action further, the documentation is [here](https://bittu.eu.org/docs/wr-intro), and the source code is [here](https://github.com/vedantmgoyal2009/winget-releaser).

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been automatically created using 🛫 WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+automatically+created+using+%F0%9F%9B%AB+WinGet+Releaser).

Misc changes:
- Remove unnecessary https://github.com/dev-drprasad/delete-tag-and-release action.