### PR TITLE
Add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,7 @@ on:
     branches: [ master ]
   schedule:
     - cron: '0 0 * * 1,3,5'
+  workflow_dispatch:
     
 jobs:
   checkver:


### PR DESCRIPTION
In cases where we need to run a new workflow and not rerun a failed workflow (https://github.com/jftuga/less-Windows/issues/18#issuecomment-1236440612), `workflow_dispatch` is needed.
![image](https://user-images.githubusercontent.com/56180050/188345553-3a3074cc-99bb-4a84-b421-7a5610445a18.png)

Please delete the release again before merging this to retrigger the workflow as well.