### PR TITLE
Update winget workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -97,16 +97,14 @@ jobs:
 
     steps:
     - name: Publish less to WinGet
-      uses: vedantmgoyal2009/winget-releaser@latest
+      uses: vedantmgoyal2009/winget-releaser@v1
       with:
         identifier: JohnTaylor.less
         release-tag: less-v${{ needs.checkver.outputs.new_version }}
         installers-regex: 'less\.exe$'
         token: ${{ secrets.WINGET_TOKEN }}
-    - name: Remove cloned winget-pkgs repository # Because Winget Releaser will attempt to clone it again
-      run: Remove-Item -Recurse -Force .\winget-pkgs\
     - name: Publish lesskey to WinGet
-      uses: vedantmgoyal2009/winget-releaser@latest
+      uses: vedantmgoyal2009/winget-releaser@v1
       with:
         identifier: JohnTaylor.lesskey
         release-tag: less-v${{ needs.checkver.outputs.new_version }}


### PR DESCRIPTION
Winget releaser now uses versioned tags instead of `latest`, and the workaround of removing the winget-pkgs folder is not needed anymore.

As mentioned in https://github.com/jftuga/less-Windows/pull/21#issuecomment-1260247351, please install the [Pull](https://github.com/apps/pull) app on the winget-pkgs fork to ensure that it is always updated.