### PR TITLE
Build for all possible architectures

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@ on:
   schedule:
     - cron: '0 0 * * 1,3,5'
   workflow_dispatch:
-    
+
 jobs:
   checkver:
     runs-on: ubuntu-latest
@@ -28,48 +28,48 @@ jobs:
         if [ -s "new.txt"  ]; then
           NEW_VERSION=$(cat new.txt)
           echo "New version is $NEW_VERSION"
-          echo ::set-output name=new_version::$NEW_VERSION
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
         fi
-        
+
   build:
     runs-on: windows-latest
     needs: checkver
     if: ${{ needs.checkver.outputs.new_version }}
-    
+    strategy:
+      matrix:
+        arch: [x64, x86, arm64, arm]
+
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
     - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ matrix.arch != 'x64' && 'amd64_' || '' }}${{ matrix.arch }}
 
     - name: Build
       run: python .\build.py
-    
+
     - name: Upload less to artifact
       uses: actions/upload-artifact@v3
       with:
-        name: less
-        path: less.exe
-    - name: Upload lesskey to artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: lesskey
-        path: lesskey.exe
+        name: less-${{ matrix.arch }}
+        path: |
+          less.exe
+          lesskey.exe
 
   release:
     needs: [checkver, build]
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: write
+
     steps:
-    - name: Get less artifact
+    - name: Get all artifacts
       uses: actions/download-artifact@v3
-      with:
-          name: less
-    - name: Get lesskey artifact
-      uses: actions/download-artifact@v3
-      with:
-        name: lesskey
-    
+    - name: Zip each artifact
+      run: find . -type d ! -path . -execdir zip -9 -rj "{}.zip" "{}" \;
+
     - uses: octokit/request-action@v2.x
       id: get_workflow_runtime
       with:
@@ -79,12 +79,11 @@ jobs:
         run_id: ${{ github.run_id }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
+
     - uses: softprops/action-gh-release@v1
       with:
         files: |
-          less.exe
-          lesskey.exe
+          *.zip
         body: Built with GitHub Actions at ${{ fromJson(steps.get_workflow_runtime.outputs.data).updated_at }}
         tag_name: less-v${{ needs.checkver.outputs.new_version }}
       env:
@@ -96,19 +95,10 @@ jobs:
     runs-on: windows-latest # action can only run on Windows
 
     steps:
-    - name: Publish less to WinGet
-      uses: vedantmgoyal2009/winget-releaser@v1
+    - uses: vedantmgoyal2009/winget-releaser@v1
       with:
         identifier: JohnTaylor.less
         version: ${{ needs.checkver.outputs.new_version }}
         release-tag: less-v${{ needs.checkver.outputs.new_version }}
-        installers-regex: 'less\.exe$'
-        token: ${{ secrets.WINGET_TOKEN }}
-    - name: Publish lesskey to WinGet
-      uses: vedantmgoyal2009/winget-releaser@v1
-      with:
-        identifier: JohnTaylor.lesskey
-        version: ${{ needs.checkver.outputs.new_version }}
-        release-tag: less-v${{ needs.checkver.outputs.new_version }}
-        installers-regex: 'lesskey\.exe$'
+        installers-regex: '\.zip$'
         token: ${{ secrets.WINGET_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GNU [less](https://en.wikipedia.org/wiki/Less_\(Unix\)) compiled for Windows 10 
 
 ## Download
 
-A stand-alone 64-bit Windows 10 binary for `less.exe` (and `lesskey.exe`) is provided on the [Releases Page](https://github.com/jftuga/less-Windows/releases).
+Binaries for `less.exe` (and `lesskey.exe`) are provided on the [Releases Page](https://github.com/jftuga/less-Windows/releases). Download the appropriate one for your system.
 
 ### [GitHub Actions](https://github.com/jftuga/less-Windows/actions)
 
@@ -12,7 +12,7 @@ The actions check for new versions 3 times a week. The `GitHub Actions` builds a
 
 ### Winget
 
-A new version is pushed to the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) for every release. To install less and lesskey in Winget, run the following commands:
+A new version is pushed to the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) for every release. To install less in Winget, run the following commands:
 
 ```powershell
 winget install JohnTaylor.less

--- a/build.py
+++ b/build.py
@@ -19,8 +19,6 @@ import urllib.request
 import zipfile
 from shared import download_less_web_page, get_latest_version_url, LESSURL
 
-COMPILE = r'"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"'
-
 
 def download_and_save(url: str) -> bool:
     """Download the less .zip file and save it to the current directory
@@ -74,7 +72,6 @@ def create_compile_batchfile(archive_dest: str):
         with open(bat, "w") as fp:
             fp.write("@echo off\n")
             fp.write("cd %s\n" % (archive_dest))
-            fp.write("call %s\n" % (COMPILE))
             fp.write("nmake /f Makefile.wnm\n")
             fp.write("copy /y less.exe ..\n")
             fp.write("copy /y lesskey.exe ..\n")


### PR DESCRIPTION
- Resolves #29, build for all possible architectures. Binaries are now provided via zip for convenience.
- Resolves #28 
- Update deprecated `::set-output` command to new syntax.